### PR TITLE
Fixed styling on footer

### DIFF
--- a/src/lib/layout/Footer.svelte
+++ b/src/lib/layout/Footer.svelte
@@ -3,7 +3,7 @@
 </script>
 
 <footer
-	class="mt-6 flex items-center justify-center bg-slate-200 py-6 underline-offset-1 dark:bg-slate-800"
+	class="bg-slate-200 py-6 underline-offset-1 dark:bg-slate-800 text-center"
 >
 	Created by
 	<!-- Iterate over authors and join appropriately. -->


### PR DESCRIPTION
Hi, I updated your classes and resolved #5.

remove flex, mt-6, items-center and justify-center, none are necessary.

text-center will resolve the issue entirely. Scales appropriately on all mobile, tablet and desktop.

Mobile:
![image](https://user-images.githubusercontent.com/5696449/159104788-23f54a06-611f-455b-a52f-cb8f529689d1.png)

Tablet:
![image](https://user-images.githubusercontent.com/5696449/159104806-dd519ee1-8cde-4a91-8e89-44baa8e658e6.png)

Desktop:
![image](https://user-images.githubusercontent.com/5696449/159104813-83537640-99d3-4c6d-b4a4-ca248a3cfe00.png)